### PR TITLE
Improve short-circuiting of createCart

### DIFF
--- a/src/Order.js
+++ b/src/Order.js
@@ -319,13 +319,16 @@ export default class Order {
 								ordersMap[order.referenceID] = orderCurrent;
 								resolve();
 							}, error => {
+								if (error.body && error.body.ordRejReason) {
+									ordersMap[order.referenceID] = new Order(error.body);
+								}
 								resolve();
 							});
 						})),
 					).then(() => {
 						let shouldRetry = false;
 						for (const reference in ordersMap) {
-							const thisStatus = ordersMap[reference].status;
+							const thisStatus = ordersMap[reference].ordStatus;
 							if (!thisStatus
 								|| thisStatus === Order.STATUSES.NEW
 								|| thisStatus === Order.STATUSES.PARTIAL_FILL


### PR DESCRIPTION
Previously, `createCart` looked for the `status` property to determine if it should re-check orders, causing unnecessary re-checks—the correct property name is `ordStatus` 👎 